### PR TITLE
Update whitespace job to ignore '.git' directory

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,10 @@ whitelist_externals = rm
 [testenv:whitespace]
 deps =
 commands_pre =
-commands = /bin/sh -c '! grep -nRI " $" --exclude-dir=.tox --exclude-dir=venv'
+commands = /bin/sh -c '! grep -nRI " $" \
+  --exclude-dir=.tox \
+  --exclude-dir=venv \
+  --exclude-dir=.git'
 whitelist_externals =
   sh
   grep


### PR DESCRIPTION
This was flagging commit messages which don't matter if they have
accidental trailing whitespace.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>