### PR TITLE
Update Release Documentation

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -5,21 +5,26 @@ Release Steps
 
   git tag -s VERSION
 
+#. Create a Source Distribution::
+
+  python setup.py sdist
+
 #. Create a Wheel::
 
   python setup.py bdist_wheel
 
-#. Create a detached signature of the wheel::
+#. Create a detached signature of the wheel and sdist::
 
-  gpg -b dist/*
+  for relfile in dist/*; do gpg -a --detach-sign $relfile; done
 
 #. Upload both to pypi Test::
 
   twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-#. Verify the install works from pypi test::
+#. Verify the install works on both from pypi test::
 
-   pip install --index-url https://test.pypi.org/simple/ newsreader
+  pip install --extra-index-url https://test.pypi.org/simple/ --only-binary wheel --no-cache-dir newsreader
+  pip install --extra-index-url https://test.pypi.org/simple/ --no-cache-dir --no-binary newsreader newsreader
 
 #. Upload the package and signature to pypi prod::
 


### PR DESCRIPTION
GPG detached signatures need to be done one at a time, as the
'--detach-sign' won't accept multiple files.

Notes on how to install just a wheel or just a source distribution were
added.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>