### PR TITLE
Add Configuration File

### DIFF
--- a/doc/man/nr-config.5
+++ b/doc/man/nr-config.5
@@ -1,6 +1,19 @@
 .TH NR-CONFIG 5
-.SH NR-CONFIG
+.SH NAME
 nr-config \- the nr config file
+.SH SYNOPSIS
+.I nr.ini
+.TP
+.I ~/.config/nr.ini
+.SH DESCRIPTION
+This manual page describes the format of the \fInr.ini\fR file.
+.SH CONFIGURATION FILE
+.BR
+.EX
+[newsreader]
+width = 40
+align = center
+sites = https://text.npr.org/
 .SH AUTHOR
 Written by Trevor Bramwell <\fItrevor@bramwell.net\fR>
 .SH "SEE ALSO"


### PR DESCRIPTION
Add the ability to configure newsreader through a '~/.config/nr.ini' or
current directory 'nr.ini' file. Supported options are:

 * width (default 40) - percentage of total width to use as padding
 * align (default 'center') - article alignment in reader
 * sites (default 'text.npr.org') - list of sites to pull articles from

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>