### PR TITLE
Ensure packages are build on Tags as well

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,7 @@ package-build:
           - build/
           - dist/
   only:
+      - tags
       - master@bramwelt/newsreader
 
 publish-to-test:


### PR DESCRIPTION
Dependent builds apparently don't get added to a pipeline unless they
include the same triggers. In this case 'publish-to-prod' failed because
'package-build' didn't run even though it is listed as a dependency.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>