### PR TITLE
Use the python:3 image a default

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
-image: python:3-slim
+image: python:3
 stages:
   - verify
   - build
@@ -18,7 +18,6 @@ pylint:
 
 package-build:
   stage: build
-  image: python:3
   script: python setup.py sdist bdist_wheel
   artifacts:
       expire_in: 1 day


### PR DESCRIPTION
Without 'git' installed, pbr fails to find the package version which
disables the ability to set 'sdist = False' in tox.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>