### PR TITLE
Move Site and Article classes to own file

### DIFF
--- a/nr/article.py
+++ b/nr/article.py
@@ -1,0 +1,49 @@
+"""
+Newsreader - Article
+
+Copyright (c) 2018 Trevor Bramwell <trevor@bramwell.net>
+SPDX-License-Identifier: Apache-2.0
+"""
+import urwid
+import requests
+from bs4 import BeautifulSoup
+
+
+class Article(urwid.SelectableIcon):
+    """Articles represent pages from a news Site. They are parsed and """
+
+    def __init__(self, text, link):
+        # Set the cursor to just beyond the article text so it is
+        # 'hidden'
+        curs_pos = len(text)+1
+        super(Article, self).__init__(text, cursor_position=curs_pos)
+        self.site = "NPR"
+        self.link = link
+        self.parsed = False
+        self.body = []
+
+    def keypress(self, size, key):
+        """Handle keypresses by emitting signals"""
+        if key == 'enter':
+            # Emit a 'select' event so we can handle key presses in
+            # another place.
+            urwid.emit_signal(self, 'select', self)
+            return None
+        return key
+
+    def parse(self):
+        """Parse an article and extract the contents"""
+        if not self.parsed:
+            page = requests.get(self.link)
+            soup = BeautifulSoup(page.content, 'html.parser')
+            for i, par in enumerate(soup.body.find_all('p')[2:]):
+                # NPR Specific
+                if i < 2:
+                    self.body.append(
+                        urwid.AttrMap(urwid.Text(par.text), 'bold'))
+                else:
+                    self.body.append(urwid.Divider())
+                    self.body.append(urwid.Text(par.text))
+
+
+urwid.register_signal(Article, 'select')

--- a/nr/main.py
+++ b/nr/main.py
@@ -13,9 +13,9 @@ from os.path import expanduser
 import urwid
 from urwid import curses_display
 
-import requests
 import requests_cache
-from bs4 import BeautifulSoup
+
+from .site import Site
 
 # import logging
 # logging.basicConfig(filename='nr.log', level=logging.INFO)
@@ -36,72 +36,6 @@ urwid.command_map['ctrl f'] = 'cursor page down'
 def getlist(option):
     """ConfigParser method for extracting list from config file"""
     return [item.strip() for item in option.split(',')]
-
-
-class Site():
-    """News site containing links to news articles
-       (ex: text.npr.org, lite.cnn.org)"""
-
-    def __init__(self, url):
-        self.url = url
-        self.articles = []
-
-    def parse(self):
-        """Parse a site and extract the articles"""
-        # logging.info("Parsing: %s", self.url)
-        page = requests.get(self.url)
-        soup = BeautifulSoup(page.content, 'html.parser')
-        links = soup.body.ul.find_all('li')
-        for link in links:
-            # logging.info("Adding article: %s", link)
-            href = "%s%s" % (self.url, link.a['href'])
-            article = Article(link.text, href)
-            self.articles.append(article)
-
-    def get_articles(self):
-        """Return articles from the site, requires the site have been
-           parsed first"""
-        return self.articles
-
-
-class Article(urwid.SelectableIcon):
-    """News Article - A button that when clicked displays the article"""
-
-    def __init__(self, text, link):
-        # Set the cursor to just beyond the article text so it is
-        # 'hidden'
-        curs_pos = len(text)+1
-        super(Article, self).__init__(text, cursor_position=curs_pos)
-        self.site = "NPR"
-        self.link = link
-        self.parsed = False
-        self.body = []
-
-    def keypress(self, size, key):
-        """Handle keypresses by emitting signals"""
-        if key == 'enter':
-            # Emit a 'select' event so we can handle key presses in
-            # another place.
-            urwid.emit_signal(self, 'select', self)
-            return None
-        return key
-
-    def parse(self):
-        """Parse an article and extract the contents"""
-        if not self.parsed:
-            page = requests.get(self.link)
-            soup = BeautifulSoup(page.content, 'html.parser')
-            for i, par in enumerate(soup.body.find_all('p')[2:]):
-                # NPR Specific
-                if i < 2:
-                    self.body.append(
-                        urwid.AttrMap(urwid.Text(par.text), 'bold'))
-                else:
-                    self.body.append(urwid.Divider())
-                    self.body.append(urwid.Text(par.text))
-
-
-urwid.register_signal(Article, 'select')
 
 
 class App():

--- a/nr/site.py
+++ b/nr/site.py
@@ -1,0 +1,36 @@
+"""
+Newsreader - Site
+
+Copyright (c) 2018 Trevor Bramwell <trevor@bramwell.net>
+SPDX-License-Identifier: Apache-2.0
+"""
+import requests
+from bs4 import BeautifulSoup
+
+from .article import Article
+
+
+class Site():
+    """A site represents a news source and contains a list of articles
+       after being parsed"""
+
+    def __init__(self, url):
+        self.url = url
+        self.articles = []
+
+    def parse(self):
+        """Parse a site and extract the articles"""
+        # logging.info("Parsing: %s", self.url)
+        page = requests.get(self.url)
+        soup = BeautifulSoup(page.content, 'html.parser')
+        links = soup.body.ul.find_all('li')
+        for link in links:
+            # logging.info("Adding article: %s", link)
+            href = "%s%s" % (self.url, link.a['href'])
+            article = Article(link.text, href)
+            self.articles.append(article)
+
+    def get_articles(self):
+        """Return articles from the site, requires the site have been
+           parsed first"""
+        return self.articles

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-skipsdist = True
+skipsdist = False
 envlist = pylint, pycodestyle, whitespace
 # commands_pre wasn't introduced till 3.4.0
 #  if you want to run tox before this version remove the line


### PR DESCRIPTION
Since these are classes they should be in their own files. This will
help when refactoring the parsing later on.

Signed-off-by: Trevor Bramwell <trevor@bramwell.net>